### PR TITLE
Load database gracefully to allow running manage commands w/o a database.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -66,7 +66,7 @@ def updatedb():
         with open('vlasisku/data/jbovlaste.xml', 'w') as file:
             xml.write(file, 'utf-8')
         os.system('''
-            rm vlasisku/data/db.pickle
+            rm -f vlasisku/data/db.pickle
             touch app.wsgi
             ''')
 

--- a/vlasisku/__init__.py
+++ b/vlasisku/__init__.py
@@ -9,7 +9,7 @@ app = Flask(__name__)
 genshi.init_app(app)
 database.init_app(app)
 
-ETAG = database.root.etag
+ETAG = database.etag
 
 app.config.from_object(__name__)
 


### PR DESCRIPTION
Without this fix, `manage.py updatedb` (or any other manage.py command, for that matter) fails to run [1] when there is no database file.

Change summary:
- vlasisku package loads successfully even if no database file can be found.
- If no database file was found, vlasisku.app returns 503 upon request.
- updatedb command runs without db.pickle being present.

[1] Traceback:

```
$ python manage.py updatedb
Traceback (most recent call last):
  File "manage.py", line 8, in <module>
    from vlasisku import app
  File "/path/to/vlasisku/vlasisku/__init__.py", line 10, in <module>
    database.init_app(app)
  File "/path/to/vlasisku/vlasisku/database.py", line 137, in init_app
    root = Root(self)
  File "/path/to/vlasisku/vlasisku/database.py", line 188, in __init__
    with open(join(root_path, jbovlaste)) as f:
IOError: [Errno 2] No such file or directory: '/path/to/vlasisku/vlasisku/data/jbovlaste.xml'
```
