### PR TITLE
Changed to github.io

### DIFF
--- a/vlasisku/database.py
+++ b/vlasisku/database.py
@@ -439,7 +439,7 @@ class Root(object):
         if text in self.cll:
             for path in self.cll[text]:
                 section = '%s.%s' % tuple(path)
-                link = 'http://dag.github.com/cll/%s/%s/'
+                link = 'http://dag.github.io/cll/%s/%s/'
                 entry.cll.append((section, link % tuple(path)))
 
     def _process_definition(self, entry, text):


### PR DESCRIPTION
A while ago Github pages (where the online CLL is hosted) changed their domain to github.io. The links for various CLL chapters in vlasisku are still pointing to "dag.github.com", where it should be "dag.github.io"

i.e
http://dag.github.com/cll/13/12/

Should be:
http://dag.github.io/cll/13/12/

Github automatically redirects you but we should be linking to the correct page anyway.

More Information:
https://github.com/blog/1452-new-github-pages-domain-github-io
