### PR TITLE
Changed links from Launchpad to GitHub

### DIFF
--- a/copyrights.yml
+++ b/copyrights.yml
@@ -4,7 +4,7 @@ vlasisku:
         - vlasisku/static/custom.*
         - "*.py"
     copyright: Copyright © 2010 Dag Odenhall <dag.odenhall@gmail.com>
-    url: https://launchpad.net/vlasisku
+    url: https://github.com/dag/vlasisku/
     license: http://www.gnu.org/licenses/agpl-3.0.html
 
 Blueprint CSS framework:

--- a/vlasisku/templates/layout.html
+++ b/vlasisku/templates/layout.html
@@ -30,7 +30,7 @@
           <div id="nav">
             <ol>
               <li><a href="${url_for('app.index')}" rel="index" accesskey="h">Home</a></li>
-              <li><a href="https://bugs.launchpad.net/vlasisku/+filebug" title="Found a bug? Report it!" accesskey="b">Bugs</a></li>
+              <li><a href="https://github.com/dag/vlasisku/issues" title="Found a bug? Report it!" accesskey="b">Bugs</a></li>
               <li><a href="${url_for('pages.help')}" accesskey="?">Help</a></li>
             </ol>
           </div>


### PR DESCRIPTION
As requested. This will now link to GitHub's issue tracker.

I also changed the copyright.yml to link to vlasisku on GitHub.
