### PR TITLE
Fix default no-op lamda to have correct number of params.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@
 
 from __future__ import with_statement
 
-from flaskext.script import Manager
+from flask.ext.script import Manager
 
 from vlasisku import app
 

--- a/vlasisku/database.py
+++ b/vlasisku/database.py
@@ -416,7 +416,7 @@ class Root(object):
 
                     for child in valsi.getchildren():
                         tag, text = child.tag, child.text
-                        processors.get(tag, lambda: None)(entry, text)
+                        processors.get(tag, lambda e, t: None)(entry, text)
 
                     self.entries[entry.word] = entry
 


### PR DESCRIPTION
Fix for this (Python 2.7.5, FreeBSD 9.1):

```
Traceback (most recent call last):
  File "./manage.py", line 8, in <module>
    from vlasisku import app
  File "/export/home/ders/code/vlasisku/vlasisku/__init__.py", line 10, in <module>
    database.init_app(app)
  File "/export/home/ders/code/vlasisku/vlasisku/database.py", line 138, in init_app
    root = self._load_from_source(cache_path)
  File "/export/home/ders/code/vlasisku/vlasisku/database.py", line 162, in _load_from_source
    root = Root(self)
  File "/export/home/ders/code/vlasisku/vlasisku/database.py", line 217, in __init__
    self._load_entries(xml)
  File "/export/home/ders/code/vlasisku/vlasisku/database.py", line 419, in _load_entries
    processors.get(tag, lambda: None)(entry, text)
TypeError: <lambda>() takes no arguments (2 given)
```
